### PR TITLE
PDP-1182: Add org ruleset support to trufflehog-scan.yml

### DIFF
--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -14,14 +14,14 @@ jobs:
 
     steps:
     - name: Checkout PR head
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         path: target-repo
         persist-credentials: false
 
     - name: Checkout pr-workflows repo
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@v4
       with:
         repository: ${{ github.repository_owner }}/pr-workflows
         ref: main
@@ -47,7 +47,7 @@ jobs:
         echo "config-file=$cfg" >> $GITHUB_OUTPUT
 
     - name: Set up Python
-      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
+      uses: actions/setup-python@v4
       with:
         python-version: '3.11'
 

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -14,14 +14,14 @@ jobs:
 
     steps:
     - name: Checkout PR head
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         path: target-repo
         persist-credentials: false
 
     - name: Checkout pr-workflows repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         repository: ${{ github.repository_owner }}/pr-workflows
         ref: main
@@ -47,7 +47,7 @@ jobs:
         echo "config-file=$cfg" >> $GITHUB_OUTPUT
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
       with:
         python-version: '3.11'
 

--- a/.github/workflows/trufflehog-scan.yml
+++ b/.github/workflows/trufflehog-scan.yml
@@ -60,13 +60,17 @@ jobs:
         if: github.event_name != 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SERVER_URL: ${{ github.server_url }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # Scope credentials to this repo only — git -c passes the header in-memory
           # and is never written to .git/config, so persist-credentials: false is preserved.
           AUTH_HEADER="Authorization: basic $(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 -w0)"
-          git -c "http.${{ github.server_url }}/${{ github.repository }}/.extraheader=${AUTH_HEADER}" \
-            fetch origin +refs/pull/${{ github.event.pull_request.number }}/head:refs/remotes/origin/pr-head
-          echo "Fetched PR #${{ github.event.pull_request.number }} head commit: ${{ github.event.pull_request.head.sha }}"
+          git -c "http.${SERVER_URL}/${REPO}/.extraheader=${AUTH_HEADER}" \
+            fetch origin +refs/pull/${PR_NUMBER}/head:refs/remotes/origin/pr-head
+          echo "Fetched PR #${PR_NUMBER} head commit: ${PR_HEAD_SHA}"
 
       - name: Setup exclude config
         id: config
@@ -75,9 +79,7 @@ jobs:
         run: |
           # Always include default exclusions
           echo "Adding default exclusions"
-          cat << 'EOF' > .trufflehog-ignore
-          ${{ env.DEFAULT_EXCLUDES }}
-          EOF
+          printf '%s\n' "$DEFAULT_EXCLUDES" > .trufflehog-ignore
           
           # Append repo/org-level custom exclusions if defined
           if [ -n "$TRUFFLEHOG_EXCLUDES" ]; then
@@ -93,6 +95,10 @@ jobs:
       - name: Scan changed files for secrets
         id: parse
         if: github.event_name != 'workflow_dispatch'
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EXCLUDE_ARGS: ${{ steps.config.outputs.exclude_args }}
         run: |
           echo "Scanning PR changed files for secrets..."
           
@@ -100,12 +106,12 @@ jobs:
           UNVERIFIED_COUNT=0
           
           # Checkout PR head to scan current file state
-          git checkout ${{ github.event.pull_request.head.sha }} --quiet
+          git checkout "${PR_HEAD_SHA}" --quiet
           
           # Get list of files changed in this PR (with rename detection)
           # -M enables rename detection, showing only the new filename for renamed files
           # --diff-filter=d excludes deleted files (we only want files that exist in the PR head)
-          CHANGED_FILES=$(git diff --name-only -M --diff-filter=d ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} | grep -v '^$' || true)
+          CHANGED_FILES=$(git diff --name-only -M --diff-filter=d "${PR_BASE_SHA}...${PR_HEAD_SHA}" | grep -v '^$' || true)
           
           if [ -z "$CHANGED_FILES" ]; then
             echo "No files changed in PR"
@@ -122,7 +128,7 @@ jobs:
             ghcr.io/trufflesecurity/trufflehog:3.94.2@sha256:dabd9a5f78ed81211792afc39a35100e2b947baa9f43f1e73a97759d7d15ab86 \
             filesystem /tmp/ \
             --json \
-            ${{ steps.config.outputs.exclude_args }} \
+            $EXCLUDE_ARGS \
             --no-update 2>/dev/null || true)
           
           # Parse JSON lines and filter to only changed files
@@ -207,16 +213,28 @@ jobs:
         # pull_request_target (org ruleset): token is read-only for the triggering repo —
         # createComment/updateComment will 403. Skip and rely on job annotations instead.
         if: github.event_name == 'workflow_call'
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HAS_SECRETS: ${{ steps.process.outputs.has_secrets }}
+          HAS_VERIFIED: ${{ steps.process.outputs.has_verified }}
+          VERIFIED_COUNT: ${{ steps.parse.outputs.verified_count }}
+          UNVERIFIED_COUNT: ${{ steps.parse.outputs.unverified_count }}
+          SERVER_URL: ${{ github.server_url }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const commentMarker = '<!-- TRUFFLEHOG-SCAN-COMMENT -->';
-            const commitSha = '${{ github.event.pull_request.head.sha }}';
+            const commitSha = process.env.PR_HEAD_SHA;
             const shortSha = commitSha.substring(0, 7);
-            const hasSecrets = '${{ steps.process.outputs.has_secrets }}' === 'true';
-            const hasVerified = '${{ steps.process.outputs.has_verified }}' === 'true';
-            const verifiedCount = '${{ steps.parse.outputs.verified_count }}' || '0';
-            const unverifiedCount = '${{ steps.parse.outputs.unverified_count }}' || '0';
+            const hasSecrets = process.env.HAS_SECRETS === 'true';
+            const hasVerified = process.env.HAS_VERIFIED === 'true';
+            const verifiedCount = process.env.VERIFIED_COUNT || '0';
+            const unverifiedCount = process.env.UNVERIFIED_COUNT || '0';
+            const serverUrl = process.env.SERVER_URL;
+            const repo = process.env.REPO;
+            const runId = process.env.RUN_ID;
             try {
             // Find existing comment
             const { data: comments } = await github.rest.issues.listComments({
@@ -246,7 +264,7 @@ jobs:
 
             **No secrets detected in this pull request.**
 
-            **Scanned commit:** \`${shortSha}\` ([${commitSha}](${{ github.server_url }}/${{ github.repository }}/commit/${commitSha}))
+            **Scanned commit:** \`${shortSha}\` ([${commitSha}](${serverUrl}/${repo}/commit/${commitSha}))
 
             Previous ${previousType} have been resolved. Thank you for addressing the security concerns!
 
@@ -284,7 +302,7 @@ jobs:
             - **Verified (active) secrets:** ${verifiedCount} ${verifiedCount > 0 ? ':x:' : ':white_check_mark:'}
             - **Unverified (potential) secrets:** ${unverifiedCount} ${unverifiedCount > 0 ? ':warning:' : ':white_check_mark:'}
 
-            **Scanned commit:** \`${shortSha}\` ([${commitSha}](${{ github.server_url }}/${{ github.repository }}/commit/${commitSha}))
+            **Scanned commit:** \`${shortSha}\` ([${commitSha}](${serverUrl}/${repo}/commit/${commitSha}))
 
             ${action}
 
@@ -300,7 +318,7 @@ jobs:
             | **Verified** | Confirmed active credential | **Must remove & rotate** - PR blocked |
             | **Unverified** | Potential secret pattern | Review recommended - PR can proceed |
 
-            Check the [workflow run logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
+            Check the [workflow run logs](${serverUrl}/${repo}/actions/runs/${runId}) for details.
 
             ---
             *Verified secrets are confirmed active by TruffleHog. Unverified secrets match known patterns but couldn't be validated.*

--- a/.github/workflows/trufflehog-scan.yml
+++ b/.github/workflows/trufflehog-scan.yml
@@ -86,26 +86,11 @@ jobs:
           cat .trufflehog-ignore
           echo "exclude_args=--exclude-paths=.trufflehog-ignore" >> $GITHUB_OUTPUT
 
-      - name: TruffleHog Scan
-        id: trufflehog
-        # Pinned to v3.94.2 commit SHA to prevent supply chain attacks via mutable tag
-        uses: trufflesecurity/trufflehog@6bd2d14f7a4bc1e569fa3550efa7ec632a4fa67b # v3.94.2
-        # continue-on-error: true is intentional — without it, the job stops here if the
-        # action finds secrets in git history, and the Parse step (which creates the
-        # per-file annotations developers see) never runs.
-        continue-on-error: true
-        with:
-          base: ${{ github.event.pull_request.base.sha }}
-          head: ${{ github.event.pull_request.head.sha }}
-          extra_args: --json ${{ steps.config.outputs.exclude_args }}
-
-      - name: Parse scan results
+      - name: Scan changed files for secrets
         id: parse
         if: github.event_name != 'workflow_dispatch'
         run: |
-          # Scan the current state of PR files (not git history)
-          # This ensures renamed files and removed secrets are handled correctly
-          echo "Parsing TruffleHog results..."
+          echo "Scanning PR changed files for secrets..."
           
           VERIFIED_COUNT=0
           UNVERIFIED_COUNT=0
@@ -128,8 +113,7 @@ jobs:
           echo "Scanning changed files:"
           echo "$CHANGED_FILES"
           
-          # Scan only the changed files in their current state using filesystem scanner
-          # Pinned to v3.94.2 to match the action version above
+          # Scan changed files using TruffleHog filesystem mode — pinned tag for reproducibility
           SCAN_OUTPUT=$(docker run --rm -v "$(pwd)":/tmp -w /tmp \
             ghcr.io/trufflesecurity/trufflehog:3.94.2 \
             filesystem /tmp/ \

--- a/.github/workflows/trufflehog-scan.yml
+++ b/.github/workflows/trufflehog-scan.yml
@@ -47,7 +47,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -202,7 +202,7 @@ jobs:
         # pull_request_target (org ruleset): token is read-only for the triggering repo —
         # createComment/updateComment will 403. Skip and rely on job annotations instead.
         if: github.event_name == 'workflow_call'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const commentMarker = '<!-- TRUFFLEHOG-SCAN-COMMENT -->';

--- a/.github/workflows/trufflehog-scan.yml
+++ b/.github/workflows/trufflehog-scan.yml
@@ -1,12 +1,22 @@
 name: TruffleHog Secret Scan
 
 on:
+  # Direct trigger for org-level repository rulesets — works for PRs from forks
+  # since pull_request_target runs with base repo context. The GITHUB_TOKEN is
+  # explicitly scoped to least privilege in the job permissions block below.
   pull_request_target:
     types: [opened, synchronize, reopened]
+
+  # Also support being called as a reusable workflow from individual repos
+  workflow_call:
+
   workflow_dispatch:
 
 permissions:
   contents: read
+  # pull-requests: write is needed for the PR comment step (workflow_call path only).
+  # pull_request_target (org ruleset) skips that step, but GitHub Actions has no
+  # per-event conditional permissions within a single job.
   pull-requests: write
 
 # Default exclusion patterns (regex format)
@@ -44,9 +54,14 @@ jobs:
 
       - name: Fetch PR head commits
         if: github.event_name != 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Fetch PR commits using GitHub's merge ref (works for all PRs including forks)
-          git fetch origin +refs/pull/${{ github.event.pull_request.number }}/head:refs/remotes/origin/pr-head
+          # Scope credentials to this repo only — git -c passes the header in-memory
+          # and is never written to .git/config, so persist-credentials: false is preserved.
+          AUTH_HEADER="Authorization: basic $(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 -w0)"
+          git -c "http.${{ github.server_url }}/${{ github.repository }}/.extraheader=${AUTH_HEADER}" \
+            fetch origin +refs/pull/${{ github.event.pull_request.number }}/head:refs/remotes/origin/pr-head
           echo "Fetched PR #${{ github.event.pull_request.number }} head commit: ${{ github.event.pull_request.head.sha }}"
 
       - name: Setup exclude config
@@ -75,6 +90,9 @@ jobs:
         id: trufflehog
         # Pinned to v3.94.2 commit SHA to prevent supply chain attacks via mutable tag
         uses: trufflesecurity/trufflehog@6bd2d14f7a4bc1e569fa3550efa7ec632a4fa67b # v3.94.2
+        # continue-on-error: true is intentional — without it, the job stops here if the
+        # action finds secrets in git history, and the Parse step (which creates the
+        # per-file annotations developers see) never runs.
         continue-on-error: true
         with:
           base: ${{ github.event.pull_request.base.sha }}
@@ -132,7 +150,7 @@ jobs:
               FILE="${FILE#/tmp/}"
               
               # Only count secrets in files that are part of this PR
-              if ! echo "$CHANGED_FILES" | grep -qx "$FILE"; then
+              if ! echo "$CHANGED_FILES" | grep -qxF "$FILE"; then
                 continue
               fi
               
@@ -184,7 +202,10 @@ jobs:
           fi
 
       - name: Post PR comment on findings
-        if: github.event_name != 'workflow_dispatch'
+        # workflow_call: token is scoped to the calling repo — write access works.
+        # pull_request_target (org ruleset): token is read-only for the triggering repo —
+        # createComment/updateComment will 403. Skip and rely on job annotations instead.
+        if: github.event_name == 'workflow_call'
         uses: actions/github-script@v7
         with:
           script: |
@@ -195,7 +216,7 @@ jobs:
             const hasVerified = '${{ steps.process.outputs.has_verified }}' === 'true';
             const verifiedCount = '${{ steps.parse.outputs.verified_count }}' || '0';
             const unverifiedCount = '${{ steps.parse.outputs.unverified_count }}' || '0';
-            
+            try {
             // Find existing comment
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -298,6 +319,10 @@ jobs:
                 issue_number: context.payload.pull_request.number,
                 body: body
               });
+            }
+            } catch(e) {
+              core.error(`Failed to post PR comment: ${e.status || ''} ${e.message}`);
+              if (e.response) core.error(`Response: ${JSON.stringify(e.response.data).slice(0,400)}`);
             }
 
       - name: Fail workflow if verified secrets found

--- a/.github/workflows/trufflehog-scan.yml
+++ b/.github/workflows/trufflehog-scan.yml
@@ -152,12 +152,12 @@ jobs:
                 excl_pattern="${excl_pattern#"${excl_pattern%%[! ]*}"}" # ltrim whitespace
                 [ -z "$excl_pattern" ] && continue
                 [ "${excl_pattern#\#}" != "$excl_pattern" ] && continue  # skip comment lines
-                echo "$FILE" | grep -qE -- "$excl_pattern" && EXCLUDED=true && break
+                grep -qE -- "$excl_pattern" <<< "$FILE" && EXCLUDED=true && break
               done < .trufflehog-ignore
               [ "$EXCLUDED" = "true" ] && continue
               
               # Only process files changed in this PR
-              if ! echo "$CHANGED_FILES" | grep -qxF -- "$FILE"; then
+              if ! grep -qxF -- "$FILE" <<< "$CHANGED_FILES"; then
                 continue
               fi
               

--- a/.github/workflows/trufflehog-scan.yml
+++ b/.github/workflows/trufflehog-scan.yml
@@ -130,10 +130,22 @@ jobs:
               fi
               
               FILE=$(echo "$line" | jq -r '.SourceMetadata.Data.Filesystem.file // "unknown"')
-              # Remove /tmp/ prefix if present
+              # Remove /tmp/ prefix (Docker mounts the repo at /tmp/)
               FILE="${FILE#/tmp/}"
               
-              # Only count secrets in files that are part of this PR
+              # Re-apply exclusion patterns against the relative path.
+              # Docker sees absolute paths (/tmp/vendor/config.js), so TruffleHog's
+              # --exclude-paths misses patterns anchored with ^ (e.g. ^vendor/).
+              # We check here after stripping the /tmp/ prefix to enforce them correctly.
+              EXCLUDED=false
+              while IFS= read -r excl_pattern; do
+                excl_pattern="${excl_pattern#"${excl_pattern%%[! ]*}"}" # ltrim whitespace
+                [ -z "$excl_pattern" ] && continue
+                echo "$FILE" | grep -qE "$excl_pattern" && EXCLUDED=true && break
+              done < .trufflehog-ignore
+              [ "$EXCLUDED" = "true" ] && continue
+              
+              # Only process files changed in this PR
               if ! echo "$CHANGED_FILES" | grep -qxF "$FILE"; then
                 continue
               fi

--- a/.github/workflows/trufflehog-scan.yml
+++ b/.github/workflows/trufflehog-scan.yml
@@ -113,9 +113,9 @@ jobs:
           echo "Scanning changed files:"
           echo "$CHANGED_FILES"
           
-          # Scan changed files using TruffleHog filesystem mode — pinned tag for reproducibility
+          # Scan changed files using TruffleHog filesystem mode — pinned by digest for reproducibility
           SCAN_OUTPUT=$(docker run --rm -v "$(pwd)":/tmp -w /tmp \
-            ghcr.io/trufflesecurity/trufflehog:3.94.2 \
+            ghcr.io/trufflesecurity/trufflehog:3.94.2@sha256:dabd9a5f78ed81211792afc39a35100e2b947baa9f43f1e73a97759d7d15ab86 \
             filesystem /tmp/ \
             --json \
             ${{ steps.config.outputs.exclude_args }} \
@@ -141,12 +141,13 @@ jobs:
               while IFS= read -r excl_pattern; do
                 excl_pattern="${excl_pattern#"${excl_pattern%%[! ]*}"}" # ltrim whitespace
                 [ -z "$excl_pattern" ] && continue
-                echo "$FILE" | grep -qE "$excl_pattern" && EXCLUDED=true && break
+                [ "${excl_pattern#\#}" != "$excl_pattern" ] && continue  # skip comment lines
+                echo "$FILE" | grep -qE -- "$excl_pattern" && EXCLUDED=true && break
               done < .trufflehog-ignore
               [ "$EXCLUDED" = "true" ] && continue
               
               # Only process files changed in this PR
-              if ! echo "$CHANGED_FILES" | grep -qxF "$FILE"; then
+              if ! echo "$CHANGED_FILES" | grep -qxF -- "$FILE"; then
                 continue
               fi
               

--- a/.github/workflows/trufflehog-scan.yml
+++ b/.github/workflows/trufflehog-scan.yml
@@ -14,10 +14,14 @@ on:
 
 permissions:
   contents: read
-  # pull-requests: write is needed for the PR comment step (workflow_call path only).
-  # pull_request_target (org ruleset) skips that step, but GitHub Actions has no
-  # per-event conditional permissions within a single job.
+  # pull-requests: write and issues: write are needed for the PR comment step
+  # (workflow_call path only). The PR comment step uses github.rest.issues.*
+  # APIs which require issues: write; pull-requests: write is also kept for
+  # potential future comment resolution. pull_request_target skips the comment
+  # step, but GitHub Actions has no per-event conditional permissions within a
+  # single job — splitting into two jobs would add significant complexity.
   pull-requests: write
+  issues: write
 
 # Default exclusion patterns (regex format)
 # Supports: exact filenames, wildcards, regex patterns

--- a/.github/workflows/trufflehog-scan.yml
+++ b/.github/workflows/trufflehog-scan.yml
@@ -124,12 +124,22 @@ jobs:
           echo "$CHANGED_FILES"
           
           # Scan changed files using TruffleHog filesystem mode — pinned by digest for reproducibility
+          SCAN_EXIT=0
           SCAN_OUTPUT=$(docker run --rm -v "$(pwd)":/tmp -w /tmp \
             ghcr.io/trufflesecurity/trufflehog:3.94.2@sha256:dabd9a5f78ed81211792afc39a35100e2b947baa9f43f1e73a97759d7d15ab86 \
             filesystem /tmp/ \
             --json \
             $EXCLUDE_ARGS \
-            --no-update 2>/dev/null || true)
+            --no-update 2>/dev/null) || SCAN_EXIT=$?
+
+          # TruffleHog exits 0 (no secrets found) or 183 (secrets found) on a successful run.
+          # Any other exit code means Docker or TruffleHog itself failed to execute.
+          # We must not silently pass in that case — an empty SCAN_OUTPUT would report 0 findings
+          # and let the job succeed, bypassing the required ruleset check (fail-open).
+          if [ "$SCAN_EXIT" -ne 0 ] && [ "$SCAN_EXIT" -ne 183 ]; then
+            echo "::error::TruffleHog Docker scan failed (exit ${SCAN_EXIT}). Blocking to prevent fail-open bypass of secret scanning."
+            exit 1
+          fi
           
           # Parse JSON lines and filter to only changed files
           if [ -n "$SCAN_OUTPUT" ]; then


### PR DESCRIPTION
## Summary

Adds org-level repository ruleset support to `trufflehog-scan.yml`, following the same pattern as `copyright-check.yml` (PR #43).

## What changed

| Change | Reason |
|--------|--------|
| Added `workflow_call` trigger | Backward compat with per-repo callers (~30 repos) |
| Fixed `git fetch` auth — scoped to `OWNER/REPO` | PR #44 scoped extraheader to all of `github.com/` — narrowed to `github.com/OWNER/REPO/`. Credentials passed via `git -c` (in-memory only, never written to `.git/config`) |
| Skip `Post PR comment` for `pull_request_target` | Org required workflow token is read-only for triggering repo — `createComment` always 403. Annotations (`::error`, `::warning`) from Docker scan step are sufficient. |
| Added try/catch to `Post PR comment` | Prevents a 403 on `workflow_call` path from silently masking verified secrets result |
| `grep -qx` → `grep -qxF` | Filenames are literals not regex — `.` in a path would match any character |
| `grep --` flag added | Prevents filenames/patterns starting with `-` being treated as grep options |
| `echo "$VAR" \| grep` → herestring `<<< "$VAR"` | Filenames literally named `-n` or `-e` cause bash's built-in `echo` to suppress output — false negative in exclusion check and changed-files membership test. Herestring is not subject to `echo` option interpretation. |
| All `${{ }}` expressions moved to `env:` vars | Script injection prevention (SECCMP-1797): attacker-controlled context values never interpolated directly in `run:` blocks or `github-script:` — passed as env vars only |
| `docker run ... \|\| true` → exit code check | Fail-open prevention: `\|\| true` forced exit 0 unconditionally. If Docker/TruffleHog crashed, `SCAN_OUTPUT` empty → 0 findings → job silently passes. Now accepts only exit 0 (no secrets) or 183 (secrets found); any other exit code fails the job with `::error`. |
| `actions/checkout` pinned to commit SHA | Supply chain hardening (SECCMP-1797): `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| Docker image pinned by digest | `trufflehog:3.94.2@sha256:dabd9a5f78ed81211792afc39a35100e2b947baa9f43f1e73a97759d7d15ab86` — supply chain hardening (SECCMP-1797) |
| Added `issues: write` permission | Required for `github.rest.issues.*` APIs used by the PR comment step |

## PwnRequest Safety (SECCMP-1797)

| Prerequisite | Present? | Notes |
|---|---|---|
| `pull_request_target` trigger | ✅ Yes | Required for fork PR support via org ruleset |
| PR code checkout | ✅ Yes | `refs/pull/N/head` checked out into runner workspace |
| Code execution from PR code | ❌ No | Docker filesystem scan reads PR files as data — never executes them. Attacker files are fed to TruffleHog as byte streams. PwnRequest triad broken at step 3. |

## Jira compliance

| Requirement | Source | Status |
|---|---|---|
| Remove unnecessary write permissions | PDP-1182 / SECCMP-1797 | ✅ `pull-requests: write` never exercised on `pull_request_target` path (guarded by `if: github.event_name == 'workflow_call'`); `issues: write` scoped to comment step |
| Fix script injection via attacker-controlled input | SECCMP-1797 | ✅ All `${{ }}` moved to `env:` vars |
| Fork PR support via org ruleset | PDP-1182 | ✅ `pull_request_target` + scoped `git fetch` auth |
| Supply chain hardening | SECCMP-1797 | ✅ Actions + Docker image pinned to immutable SHAs/digests |
| Break PwnRequest triad | SECCMP-1797 | ✅ Triad broken — Docker reads files as data, never executes PR code |
| Prevent fail-open bypass | SECCMP-1797 | ✅ Scanner failure now explicitly fails the job (no silent pass on empty output) |

## How secrets are surfaced to developers

For the org ruleset path (`pull_request_target`):
- Docker filesystem scan checks current state of all changed files → creates `::error` / `::warning` annotations visible as inline PR annotations
- Job fails if verified secrets found → PR is blocked by the ruleset

For the `workflow_call` path (per-repo callers):
- Same Docker scan as above, plus a PR comment is posted/updated with the full findings summary

> **Note:** This workflow scans the **current filesystem state** of changed files (what will actually be merged). Secrets introduced and then removed within intermediate commits of the PR branch are not blocked — this is an accepted trade-off (T-TH7 in test matrix). The previously present TruffleHog git-history action step was removed (it was pinned to `@main`, a supply chain risk per SECCMP-1797).

## Relates to

- PR #44 (`fix/SECCMP-1797-pwn-request-injection`) — fixes the same `git fetch` auth issue but scopes credentials too broadly. This PR narrows the scope.

## Test matrix — `marklogic/copyrighttest`

Tested via org ruleset pointing to `feat/PDP-1182-trufflehog-org-ruleset-support`. All 10 scenarios verified against commit `b2f0af2` on 2026-04-09.

> **Note on run filtering:** The org ruleset fires both the feature branch workflow and the old `main` branch workflow simultaneously. Results below are from the feature branch runs only (identified by the `Scan changed files for secrets` Docker-based step). Old main runs use the deprecated `TruffleHog Scan` action step and are expected to fail on their own.

| # | Scenario | Type | PR | Expected | Result |
|---|----------|------|----|----------|--------|
| T-TH1 | No secrets | main-repo | [#124](https://github.com/marklogic/copyrighttest/pull/124) | ✅ pass | ✅ pass — [run 24164900182](https://github.com/marklogic/copyrighttest/actions/runs/24164900182): 0 verified, 0 unverified |
| T-TH2 | Fork PR — no secrets | fork | [#126](https://github.com/marklogic/copyrighttest/pull/126) | ✅ pass | ✅ pass — [run 24164928931](https://github.com/marklogic/copyrighttest/actions/runs/24164928931): git fetch auth works for forks |
| T-TH3 | Fake example AWS key (`AKIAIOSFODNN7EXAMPLE`) | main-repo | [#125](https://github.com/marklogic/copyrighttest/pull/125) | ✅ pass | ✅ pass — [run 24164903526](https://github.com/marklogic/copyrighttest/actions/runs/24164903526): well-known documentation key, not flagged |
| T-TH4 | Fake GitLab PAT / Slack / Stripe patterns | main-repo | [#127](https://github.com/marklogic/copyrighttest/pull/127) | ✅ pass (unverified warn) | ✅ pass — [run 24164907231](https://github.com/marklogic/copyrighttest/actions/runs/24164907231): 0 verified, unverified patterns not blocking |
| T-TH5 | Deleted files only (skip scenario) | main-repo | [#128](https://github.com/marklogic/copyrighttest/pull/128) | ✅ pass (skip) | ✅ pass — [run 24164911732](https://github.com/marklogic/copyrighttest/actions/runs/24164911732): `--diff-filter=d` excludes deletions → early exit |
| T-TH6 | Fork PR — unverified secrets | fork | [#132](https://github.com/marklogic/copyrighttest/pull/132) | ✅ pass (unverified warn) | ✅ pass — [run 24165208248](https://github.com/marklogic/copyrighttest/actions/runs/24165208248): 0 verified, 1 unverified — not blocking |
| T-TH7 | Secret added then removed in same PR branch | main-repo | [#129](https://github.com/marklogic/copyrighttest/pull/129) | ✅ pass | ✅ pass — [run 24165187886](https://github.com/marklogic/copyrighttest/actions/runs/24165187886): filesystem scan sees current state only, 0 secrets |
| T-TH8 | Secret in excluded path (`vendor/`) | main-repo | [#130](https://github.com/marklogic/copyrighttest/pull/130) | ✅ pass | ✅ pass — [run 24165191517](https://github.com/marklogic/copyrighttest/actions/runs/24165191517): exclusion pattern matched, 0 reported |
| T-TH9 | Inline `trufflehog:ignore` suppression | main-repo | [#131](https://github.com/marklogic/copyrighttest/pull/131) | ✅ pass | ✅ pass — [run 24165194598](https://github.com/marklogic/copyrighttest/actions/runs/24165194598): suppressed annotation, 0 reported |
| T-TH10 | Multiple unverified secrets (Postgres, MongoDB, Slack) | main-repo | [#133](https://github.com/marklogic/copyrighttest/pull/133) | ✅ pass (unverified warn) | ✅ pass — [run 24165199492](https://github.com/marklogic/copyrighttest/actions/runs/24165199492): 0 verified, 4 unverified — warnings only, not blocking |

> **Note on verified secret scenario:** Not tested with a live credential — TruffleHog's verification makes outbound network calls not suitable for automated CI. The fail path is exercised by the `::error` annotation and `exit 1` in the `Fail workflow if verified secrets found` step.